### PR TITLE
validate that an orders parts are all in stock

### DIFF
--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -16,7 +16,7 @@ describe "Checkout" do
 
   shared_context "purchases product with part included" do
     before do
-      add_product_to_cart
+      add_product_to_cart product
       click_button "Checkout"
 
       fill_in "order_email", :with => "ryan@spreecommerce.com"
@@ -50,10 +50,9 @@ describe "Checkout" do
 
     context "ordering assembly and the part as individual sale" do
       before do
-        visit spree.root_path
-        click_link variant.product.name
-        click_button "add-to-cart-button"
+        add_product_to_cart variant.product
       end
+
       include_context "purchases product with part included"
 
       it "views parts bundled and not" do
@@ -78,7 +77,7 @@ describe "Checkout" do
     fill_in "#{address}_phone", :with => "(555) 555-5555"
   end
 
-  def add_product_to_cart
+  def add_product_to_cart product
     visit spree.root_path
     click_link product.name
     click_button "add-to-cart-button"

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -4,7 +4,6 @@ describe "Checkout" do
   let!(:country) { create(:country, :name => "United States", :states_required => true) }
   let!(:state) { create(:state, :name => "Ohio", :country => country) }
   let!(:shipping_method) { create(:shipping_method) }
-  let!(:stock_location) { create(:stock_location) }
   let!(:payment_method) { create(:check_payment_method) }
   let!(:zone) { create(:zone) }
 

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -65,7 +65,7 @@ describe "Checkout" do
 
   end
 
-  context 'purchasing an assembly', js: true do
+  context 'purchasing an assembly' do
     context 'and the part as individual sale' do
       context 'and the products are not backorderable' do
         before { Spree::StockItem.update_all backorderable: false }

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -6,7 +6,11 @@ describe Spree::Order do
     let(:cinco_food_tube) { create :base_product, name: 'cinco food tube' }
     let(:cinco_pack) { create :assembly, name: 'cinco pack', parts: [[cinco_food_tube.master, 1]] }
 
-    subject { order.validate_parts_supply }
+    subject { order.valid? }
+
+    context 'an order with no line_items' do
+      it { expect(order).to be_valid }
+    end
 
     before do
       allow_any_instance_of(Spree::StockItem).to receive(:backorderable).
@@ -44,12 +48,16 @@ describe Spree::Order do
 
         create :line_item, variant: cinco_food_tube.master, quantity: 1,
           order: order
+
+        order.reload
       end
+
       it 'adds an error to the order' do
         # cinco pack has 1 x food tubes
         # order has 2 x cinco pack, 1 x food tube, for a total of 3 x food tube's
         # 2 food tube's in stock
         subject
+        expect(order.errors.size).to eq 1
         expect(order.errors.full_messages.first).to match(/cinco food tube is out of stock/)
       end
     end


### PR DESCRIPTION
Validates that there is enough of a variant in stock when purchasing a kit that contains it, as well as the variant individually. 
