### PR TITLE
Update assembly inventory

### DIFF
--- a/app/models/spree/assemblies_part.rb
+++ b/app/models/spree/assemblies_part.rb
@@ -12,5 +12,9 @@ module Spree
     def available_count
       part.total_on_hand / count
     end
+
+    def count_by_stock_location
+      Hash[part.stock_items.map { |si| [si.stock_location, (si.count_on_hand / count)] }]
+    end
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -53,6 +53,16 @@ Spree::Product.class_eval do
     errors.add(:can_be_part, Spree.t(:assembly_cannot_be_part)) if can_be_part
   end
 
+  def update_assembly_inventory!
+    assemblies_parts.inject({}) do |assembly_count, part|
+      assembly_count.merge(part.count_by_stock_location) do |_, current_min, quantity |
+        [ current_min, quantity ].min
+      end
+    end.each_pair do |location, quantity|
+      location.stock_item(self).set_count_on_hand quantity
+    end
+  end
+
   private
   def assemblies_part(variant)
     Spree::AssembliesPart.get(self.id, variant.id)

--- a/spec/factories/assembly.rb
+++ b/spec/factories/assembly.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :assembly, class: 'Spree::Product', parent: :base_product do
     ignore do
-      parts []
+      parts {}
     end
 
     trait :with_parts do |n|
@@ -17,7 +17,7 @@ FactoryGirl.define do
     end
 
     after :create do |assembly, evaluator|
-      evaluator.parts.each do |part, quantity|
+      evaluator.parts.each_pair do |part, quantity|
         assembly.add_part part, quantity
       end
       assembly.save!

--- a/spec/factories/assembly.rb
+++ b/spec/factories/assembly.rb
@@ -4,15 +4,22 @@ FactoryGirl.define do
       parts []
     end
 
+    trait :with_parts do |n|
+      ignore do
+        number_of_parts 1
+      end
+
+      after :create do |assembly, evaluator|
+        evaluator.number_of_parts.times do
+          assembly.add_part create :variant
+        end
+      end
+    end
+
     after :create do |assembly, evaluator|
       evaluator.parts.each do |part, quantity|
         assembly.add_part part, quantity
       end
-
-      if assembly.parts.empty?
-        assembly.add_part create(:base_variant), 1
-      end
-
       assembly.save!
     end
   end

--- a/spec/factories/variant.rb
+++ b/spec/factories/variant.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :variant_with_stock, parent: :variant do
+    ignore do
+      stock {}
+    end
+
+    after :create do |variant, evaluator|
+      evaluator.stock.each_pair do |stock_location, new_count_on_hand|
+        stock_location.stock_item(variant).set_count_on_hand new_count_on_hand
+      end
+    end
+  end
+end

--- a/spec/models/spree/assemblies_part_spec.rb
+++ b/spec/models/spree/assemblies_part_spec.rb
@@ -18,7 +18,7 @@ module Spree
 
     describe '.available_count' do
       let(:assembly_part) { assembly.assemblies_parts.first }
-      let(:assembly) { create :assembly, parts: [[variant, 2 ]] }
+      let(:assembly) { create :assembly, parts: { variant => 2 }  }
 
       before do
         variant.stock_items.first.adjust_count_on_hand 3

--- a/spec/models/spree/assemblies_part_spec.rb
+++ b/spec/models/spree/assemblies_part_spec.rb
@@ -30,5 +30,19 @@ module Spree
         expect(subject).to eq 1
       end
     end
+
+    describe '#count_by_stock_location!' do
+      let!(:location_a) { create :stock_location }
+      let!(:cinco_fone) { create :variant_with_stock,
+                          stock: { location_a => 9 } }
+      let!(:cinco_kit) { create :assembly, parts: { cinco_fone => 2} }
+      let(:part) { cinco_kit.assemblies_parts.first }
+
+      subject { part.count_by_stock_location }
+
+      it 'is lists how many assemblies can be supplied with this part per stock location' do
+        expect(subject).to eq(location_a => 4)
+      end
+    end
   end
 end

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -4,7 +4,7 @@ describe Spree::Order do
   describe '.validate_part_supply' do
     let(:order) { create :order }
     let(:cinco_food_tube) { create :base_product, name: 'cinco food tube' }
-    let(:cinco_pack) { create :assembly, name: 'cinco pack', parts: [[cinco_food_tube.master, 1]] }
+    let(:cinco_pack) { create :assembly, name: 'cinco pack', parts: { cinco_food_tube.master => 1 } }
 
     subject { order.valid? }
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Product do
     @product = FactoryGirl.create(:product, :name => "Foo Bar")
     @master_variant = Spree::Variant.where(is_master: true).find_by_product_id(@product.id)
   end
-    
+
   describe "Spree::Product.active" do
     before(:each) do
       Spree::Product.delete_all
@@ -49,11 +49,11 @@ describe Spree::Product do
       @product.add_part @part1.master, 1
       @product.add_part @part2.master, 4
     end
-    
+
     it "is an assembly" do
       @product.should be_assembly
     end
-    
+
 
     it "cannot be part" do
       @product.should be_assembly
@@ -65,6 +65,36 @@ describe Spree::Product do
     it 'changing part qty changes count on_hand' do
       @product.set_part_count(@part2.master, 2)
       @product.count_of(@part2.master).should == 2
+    end
+  end
+
+  describe '#update_assembly_inventory!' do
+    context 'when the product is an assembly' do
+      let!(:location_a) { create :stock_location }
+      let!(:location_b) { create :stock_location }
+
+      let!(:cinco_fone) { create :variant_with_stock,
+                          stock: { location_a => 1,
+                                   location_b => 2 } }
+
+      let!(:man_nip) { create :variant_with_stock,
+                       stock: { location_a => 2,
+                                location_b => 5 } }
+
+      let!(:cinco_kit) { create :assembly,
+                         parts: { cinco_fone => 1,
+                                  man_nip => 2 } }
+
+      before { cinco_kit.update_assembly_inventory! }
+
+      it 'sets the inventory level to the minimum part level for each stock location' do
+        expect(location_a.stock_item(cinco_kit).count_on_hand).to eq 1
+        expect(location_b.stock_item(cinco_kit).count_on_hand).to eq 2
+      end
+    end
+
+    context 'when the product is not an assembly' do
+      it 'does nothing'
     end
   end
 end


### PR DESCRIPTION
Call `update_assembly_inventory!` on an assembly to update it's count on hand at each stock location to reflect how many complete kits can be constructed at that location.
