### PR TITLE
Fix nil shipment and payment states

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ end
 group :test do
   gem 'capybara', '~> 2.1.0'
   gem 'poltergeist'
+  gem 'pry-rescue'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ end
 
 group :test do
   gem 'capybara', '~> 2.1.0'
-  gem 'selenium-webdriver', '~> 2.34'
+  gem 'poltergeist'
 end

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -1,0 +1,8 @@
+Spree::OrderContents.class_eval do
+  alias_method :old_update_cart, :update_cart
+
+  def update_cart(params)
+    order.assign_attributes( params )
+    old_update_cart( params ) if order.valid? :checkout
+  end
+end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   Order.class_eval do
-    validate :validate_parts_supply
+    validate :validate_parts_supply, on: :checkout
 
     def validate_parts_supply
       quantity_by_variant = self.line_items.map(&:quantity_by_variant).flatten

--- a/app/models/spree/order_inventory_assembly.rb
+++ b/app/models/spree/order_inventory_assembly.rb
@@ -12,7 +12,7 @@ module Spree
     end
 
     def verify(shipment = nil)
-      parts_total = line_item.parts.sum {|v| line_item.count_of(v)}
+      parts_total = line_item.parts.to_a.sum {|v| line_item.count_of(v)}
 
       if inventory_units.size < (parts_total * line_item.quantity)
 

--- a/spec/models/spree/order_contents_decorator_spec.rb
+++ b/spec/models/spree/order_contents_decorator_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Spree::OrderContents do
+  describe '.update_cart' do
+    let(:order) { build :order }
+    let(:params) { {} }
+
+    it 'validates the parts supply' do
+      expect(order).to receive(:validate_parts_supply)
+      order.contents.update_cart params
+    end
+  end
+end

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Order do
     let(:cinco_food_tube) { create :base_product, name: 'cinco food tube' }
     let(:cinco_pack) { create :assembly, name: 'cinco pack', parts: { cinco_food_tube.master => 1 } }
 
-    subject { order.valid? }
+    subject { order.valid? :checkout }
 
     context 'an order with no line_items' do
       it { expect(order).to be_valid }

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -20,6 +20,13 @@ describe Spree::Order do
     end
 
     shared_examples_for "a fulfillable order" do
+      it 'does not add an error' do
+        subject
+        expect(order.errors).to be_empty
+      end
+    end
+
+    context 'when the items are capable of backorder' do
       before do
         allow_any_instance_of(Spree::StockItem).to receive(:backorderable).
           and_return true
@@ -31,17 +38,10 @@ describe Spree::Order do
           order: order
       end
 
-      it 'does not add an error' do
-        subject
-        expect(order.errors).to be_empty
-      end
-    end
-
-    context 'when the items are capable of backorder' do
       it_behaves_like 'a fulfillable order'
     end
 
-    context "when there isn't enough stock to fulfill both a line item and a assembly" do
+    context "when there isn't enough stock to fulfill both a line item and an assembly" do
       before do
         create :line_item, variant: cinco_pack.master, quantity: 2,
           order: order

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,12 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'rspec/rails'
 require 'ffaker'
 
+require 'capybara/poltergeist'
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, { js_errors: false }) # spree has js errors..
+end
+Capybara.javascript_driver = :poltergeist
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }


### PR DESCRIPTION
the validation on assembly component stock was being called in `order.finalize!`, after stock has been allocated, not allowing it to be saved if there wasn't enough stock to fulfill the order again.
