### PR TITLE
Durably decorate instead of alias method

### DIFF
--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -1,8 +1,8 @@
 Spree::OrderContents.class_eval do
-  alias_method :old_update_cart, :update_cart
 
-  def update_cart(params)
+  durably_decorate :update_cart, mode: 'strict', sha: 'f3e37d0ffd8c089d1b246e268679d5430886f2c2' do |params|
     order.assign_attributes( params )
-    old_update_cart( params ) if order.valid? :checkout
+    original_update_cart( params ) if order.valid? :checkout
   end
+
 end

--- a/spree_product_assembly.gemspec
+++ b/spree_product_assembly.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('spree_backend', '~> 2.2.0.beta')
+  s.add_dependency('durable_decorator')
 
   s.add_development_dependency 'rspec-rails', '~> 2.14.0'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Was causing an issue where, in the event that file was loaded twice, it
would overrite the aliased method, so that the old update_cart was
infact the new method - causing an infinite loop.
